### PR TITLE
Add 'file-loader' to 'devDependencies' in file 'package.json'

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-runtime": "^6.0.0",
     "css-loader": "^0.23.1",
+    "file-loader": "^0.11.1",
     "less": "^2.7.1",
     "less-loader": "^2.2.3",
     "node-sass": "^3.7.0",


### PR DESCRIPTION
There is an error:
```
ERROR in ./clear-sans.ttf
Module build failed: Error: Cannot find module 'file-loader'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.module.exports (/Users/jonnywong/GitHub/vue-2048/node_modules/.0.5.8@url-loader/index.js:18:20)
 @ ./~/.0.23.1@css-loader!./~/.0.8.2@postcss-loader!./~/.3.2.3@sass-loader!./src/assets/scss/main.scss 6:87-121
webpack: Failed to compile.
```

missing `file-loader`